### PR TITLE
Modificando a URL para buscar do novo domínio - heroku

### DIFF
--- a/src/main/java/br/com/caelum/argentum/ws/ClienteWebService.java
+++ b/src/main/java/br/com/caelum/argentum/ws/ClienteWebService.java
@@ -11,7 +11,7 @@ import br.com.caelum.argentum.reader.LeitorXML;
 
 public class ClienteWebService {
 
-	private static final String URL_WEBSERVICE = "http://argentumws.caelum.com.br/negociacoes";
+	private static final String URL_WEBSERVICE = "http://argentumws-spring.herokuapp.com/negociacoes";
 
 	public List<Negociacao> getNegociacoes() {
 


### PR DESCRIPTION
No curso, a URL antiga não funciona mais, e isso está quebrando a aplicação uma vez que ela foi buildada.
Isso tem gerado problemas. Essa solução de corrigir a URL foi sugerida no próprio fórum da Alura.
Então, tomei a liberdade de fazer essa modficação para poder lhes ajudar.
